### PR TITLE
Use a custom prepare.

### DIFF
--- a/_ci/custom-prepare.js
+++ b/_ci/custom-prepare.js
@@ -1,0 +1,21 @@
+var cp = require('child_process');
+​
+module.exports = function(cwd) {
+  return new Promise(function(resolve, reject) {
+    cp.spawn('npm', ['install', '--ignore-scripts'], {cwd: cwd})
+      .on('close', function(code) {
+        if (code != 0) {
+          return reject(code);
+        }
+        cp.spawn('node', ['lifecycleScripts/prepareForBuild.js'], {cwd: cwd})
+          .on('close', function(code) {
+            console.log('woah!');
+            console.log(code);
+            if (code != 0) {
+              return reject(code);
+            }
+            resolve();
+          });
+      });
+  });
+}


### PR DESCRIPTION
Building nodegit is Complicated®. So use a custom prepare to avoid doing more work than is necessary.
